### PR TITLE
Remove @Override decorator on createJSModules

### DIFF
--- a/android/src/main/java/com/localeutils/LocaleUtilsPackage.java
+++ b/android/src/main/java/com/localeutils/LocaleUtilsPackage.java
@@ -21,7 +21,6 @@ public class LocaleUtilsPackage implements ReactPackage {
 
   }
 
-	@Override
 	public List<Class<? extends JavaScriptModule>> createJSModules() {
 			return Collections.emptyList();
 	}


### PR DESCRIPTION
Fixes a breaking change from RN 47

https://github.com/facebook/react-native/releases/tag/v0.47.2